### PR TITLE
Make TPI times page compatible with the MPT and some RTCC bugfixes

### DIFF
--- a/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
+++ b/Orbitersdk/samples/ProjectApollo/src_launch/rtcc.h
@@ -3655,7 +3655,7 @@ public:
 
 	struct VectorPanelSummaryDisplay
 	{
-		double gmt = 0.0;
+		double gmt = -10000000000000.0;
 		//0 = CSM, 1 = LM
 		std::string AnchorVectorID[2];
 		std::string AnchorVectorGMT[2];

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.cpp
@@ -708,6 +708,7 @@ ARCore::ARCore(VESSEL* v, AR_GCore* gcin)
 	GSLOSGET = 0.0;
 	PADSolGood = true;
 	Rendezvous_Target = NULL;
+	Rendezvous_Target_Table = RTCC_MPT_CSM;
 	iuvessel = NULL;
 	TLCCSolGood = true;
 
@@ -3541,7 +3542,13 @@ int ARCore::subThread()
 
 		if (GC->MissionPlanningActive)
 		{
-			if (GC->rtcc->NewMPTTrajectory(RTCC_MPT_LM, opt.sv0))
+			std::string StaID;
+			double GMTV;
+
+			//Use landing time minus 20 minutes as vector time
+			GMTV = GC->rtcc->GMTfromGET(GC->rtcc->CZTDTGTU.GETTD) - 20.0*60.0;
+
+			if (GC->rtcc->PMSVEC(RTCC_MPT_LM, true, GMTV, "", opt.sv0, StaID))
 			{
 				Result = DONE;
 				break;
@@ -4009,13 +4016,27 @@ int ARCore::subThread()
 	break;
 	case 23: //Calculate TPI times
 	{
-		if (Rendezvous_Target == NULL)
+		VehicleDataBlock sv0;
+		if (GC->MissionPlanningActive)
 		{
-			Result = DONE;
-			break;
+			std::string StaID;
+			if (GC->rtcc->PMSVEC(Rendezvous_Target_Table, true, GC->rtcc->GMTfromGET(t_TPIguess), "", sv0, StaID))
+			{
+				Result = DONE;
+				break;
+			}
 		}
-		SV sv0 = GC->rtcc->StateVectorCalc(Rendezvous_Target);
-		GC->t_TPI = GC->rtcc->CalculateTPITimes(sv0, TPI_Mode, t_TPIguess, dt_TPI_sunrise);
+		else
+		{
+			if (Rendezvous_Target == NULL)
+			{
+				Result = DONE;
+				break;
+			}
+			sv0 = GC->rtcc->StateVectorCalcDataBlock(Rendezvous_Target);
+		}
+		SV sv1 = GC->rtcc->ConvertEphemDatatoSV(sv0.sv, sv0.Weight);
+		GC->t_TPI = GC->rtcc->CalculateTPITimes(sv1, TPI_Mode, t_TPIguess, dt_TPI_sunrise);
 
 		Result = DONE;
 	}

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ARCore.h
@@ -387,6 +387,7 @@ public:
 
 	//SATURN IB LAUNCH TARGETING
 	VESSEL* Rendezvous_Target; //Target vessel in orbit
+	int Rendezvous_Target_Table; //1 = CSM, 3 = LEM
 
 	//UPLINK
 	double AGCClockTime[2];

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.cpp
@@ -5662,6 +5662,18 @@ void ApolloRTCCMFD::set_TargetVessel()
 	CycleThroughVessels(&G->Rendezvous_Target);
 }
 
+void ApolloRTCCMFD::set_TargetVesselTable()
+{
+	if (GC->MissionPlanningActive)
+	{
+		G->Rendezvous_Target_Table = 4 - G->Rendezvous_Target_Table;
+	}
+	else
+	{
+		set_TargetVessel();
+	}
+}
+
 void ApolloRTCCMFD::CycleThroughVessels(VESSEL **v) const
 {
 	VESSEL *pVessel;

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD.h
@@ -116,6 +116,7 @@ public:
 	void set_LMVessel();
 	void set_IUVessel();
 	void set_TargetVessel();
+	void set_TargetVesselTable();
 	void CycleThroughVessels(VESSEL **v) const;
 	void menuSLVLaunchTargeting();
 	void menuSLVInsertionSVtoMPT();

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApolloRTCCMFD_Display.cpp
@@ -310,6 +310,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				{
 					GET_Display(Buffer, GC->rtcc->med_k01.ChaserThresholdGET);
 				}
+				Text(skp, x + dx, y, Buffer);
 			}
 			else
 			{
@@ -321,8 +322,8 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				{
 					PrintLMVessel(Buffer);
 				}
+				Text(skp, x, y, Buffer);
 			}
-			Text(skp, x, y, Buffer);
 			y++;
 			if (GC->MissionPlanningActive)
 			{
@@ -335,6 +336,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				{
 					GET_Display(Buffer, GC->rtcc->med_k01.TargetThresholdGET);
 				}
+				Text(skp, x + dx, y, Buffer);
 			}
 			else
 			{
@@ -346,8 +348,8 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 				{
 					PrintCSMVessel(Buffer);
 				}
+				Text(skp, x, y, Buffer);
 			}
-			Text(skp, x, y, Buffer);
 			y++;
 			Text(skp, x, y, "MOD:");
 			if (GC->rtcc->med_k01.CSIMode == 0) Text(skp, x + dx, y, "CSI");
@@ -1773,14 +1775,14 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 			}
 			sprintf(Buffer, "O: %+07.2lf°", G->VECBodyVector.z*DEG);
 			skp->Text(CW, 12 * H / 14, Buffer, strlen(Buffer));
-			skp->SetTextAlign(oapi::Sketchpad::RIGHT);
-			sprintf(Buffer, "%+07.2f R", G->VECangles.x*DEG);
-			skp->Text(W - CW, 10 * H / 14, Buffer, strlen(Buffer));
-			sprintf(Buffer, "%+07.2f P", G->VECangles.y*DEG);
-			skp->Text(W - CW, 11 * H / 14, Buffer, strlen(Buffer));
-			sprintf(Buffer, "%+07.2f Y", G->VECangles.z*DEG);
-			skp->Text(W - CW, 12 * H / 14, Buffer, strlen(Buffer));
 		}
+		skp->SetTextAlign(oapi::Sketchpad::RIGHT);
+		sprintf(Buffer, "%+07.2f R", G->VECangles.x*DEG);
+		skp->Text(W - CW, 10 * H / 14, Buffer, strlen(Buffer));
+		sprintf(Buffer, "%+07.2f P", G->VECangles.y*DEG);
+		skp->Text(W - CW, 11 * H / 14, Buffer, strlen(Buffer));
+		sprintf(Buffer, "%+07.2f Y", G->VECangles.z*DEG);
+		skp->Text(W - CW, 12 * H / 14, Buffer, strlen(Buffer));
 		break;
 	case 16:
 		skp->SetTextAlign(oapi::Sketchpad::CENTER);
@@ -6547,13 +6549,13 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		Text_Double(skp, W - CW * x, y * H / 28, "HPLOI1 %.1lf", GC->rtcc->PZMCCPLN.H_P_LPO1 / 1852.0); y++;
 		Text_Double(skp, W - CW * x, y * H / 28, "HALOI2 %.1lf", GC->rtcc->PZMCCPLN.H_A_LPO2 / 1852.0); y++;
 		Text_Double(skp, W - CW * x, y * H / 28, "HPLOI2 %.2lf", GC->rtcc->PZMCCPLN.H_P_LPO2 / 1852.0); y++;
-		Text_Double(skp, W - CW * x, y * H / 28, "REVS1 %.2lf", GC->rtcc->PZMCCPLN.REVS1); y++;
+		Text_Double(skp, W - CW * x, y * H / 28, "REVS1 %.3lf", GC->rtcc->PZMCCPLN.REVS1); y++;
 		Text_Int(skp, W - CW * x, y * H / 28, "REVS2 %d", GC->rtcc->PZMCCPLN.REVS2); y++;
 		Text_Double(skp, W - CW * x, y * H / 28, "SITEROT %.1lf°", GC->rtcc->PZMCCPLN.SITEROT*DEG); y++;
 		Text_Double(skp, W - CW * x, y * H / 28, "ETA1 %.3lf°", GC->rtcc->PZMCCPLN.ETA1*DEG); y++; y++;
 		skp->Text(W - CW * 27, y * H / 28, "Mission Constants", 17); y++;
-		Text_Double(skp, W - CW * x, y * H / 28, "M %d", GC->rtcc->PZMCCPLN.LOPC_M); y++;
-		Text_Double(skp, W - CW * x, y * H / 28, "N %d", GC->rtcc->PZMCCPLN.LOPC_N); y++;
+		Text_Int(skp, W - CW * x, y * H / 28, "M %d", GC->rtcc->PZMCCPLN.LOPC_M); y++;
+		Text_Int(skp, W - CW * x, y * H / 28, "N %d", GC->rtcc->PZMCCPLN.LOPC_N); y++;
 		Text_Double(skp, W - CW * x, y * H / 28, "I PR MAX %.3lf°", GC->rtcc->PZMCCPLN.INCL_PR_MAX*DEG);
 		break;
 	case 81:
@@ -6584,7 +6586,7 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		Text_Double(skp, CW, 2 * H / 14, "%.1lf NM", GC->rtcc->PZLOIPLN.HA_LLS);
 		Text_Double(skp, CW, 4 * H / 14, "%.2lf NM", GC->rtcc->PZLOIPLN.HP_LLS);
 		Text_Double(skp, CW, 6 * H / 14, "%.1lf°", GC->rtcc->PZLOIPLN.DW);
-		Text_Double(skp, CW, 8 * H / 14, "%.2lf", GC->rtcc->PZLOIPLN.REVS1);
+		Text_Double(skp, CW, 8 * H / 14, "%.3lf", GC->rtcc->PZLOIPLN.REVS1);
 		Text_Int(skp, CW, 10 * H / 14, "%d", GC->rtcc->PZLOIPLN.REVS2);
 		Text_Double(skp, CW, 12 * H / 14, "%.1lf°", GC->rtcc->PZLOIPLN.eta_1);
 		skp->SetTextAlign(oapi::Sketchpad::RIGHT);
@@ -7150,7 +7152,21 @@ bool ApolloRTCCMFD::Update(oapi::Sketchpad *skp)
 		skp->SetTextAlign(oapi::Sketchpad::CENTER);
 		skp->Text(W / 2, CH / 2, "TPI TIMES", 9);
 		skp->SetTextAlign(oapi::Sketchpad::LEFT);
-		PrintTargetVessel(Buffer);
+		if (GC->MissionPlanningActive)
+		{
+			if (G->Rendezvous_Target_Table == RTCC_MPT_CSM)
+			{
+				sprintf(Buffer, "CSM");
+			}
+			else
+			{
+				sprintf(Buffer, "LEM");
+			}
+		}
+		else
+		{
+			PrintTargetVessel(Buffer);
+		}
 		skp->Text(CW, 2 * H / 14, Buffer, strlen(Buffer));
 		if (G->TPI_Mode == 0)
 		{

--- a/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApollomfdButtons.cpp
+++ b/Orbitersdk/samples/ProjectApollo/src_rtccmfd/ApollomfdButtons.cpp
@@ -3135,14 +3135,14 @@ ApolloRTCCMFDButtons::ApolloRTCCMFDButtons()
 
 	static const MFDBUTTONMENU mnu92[] =
 	{
-		{ "Set CSM", 0, 'T' },
-		{ "", 0, ' ' },
-		{ "", 0, ' ' },
-		{ "", 0, ' ' },
+		{ "Set vessel", 0, 'T' },
+		{ "Cycle mode", 0, 'Q' },
+		{ "Enter DT", 0, 'V' },
+		{ "Enter estimated time", 0, 'L' },
 		{ "", 0, ' ' },
 		{ "", 0, ' ' },
 
-		{ "", 0, ' ' },
+		{ "Calculate TPI time", 0, 'C' },
 		{ "", 0, ' ' },
 		{ "", 0, ' ' },
 		{ "", 0, ' ' },
@@ -3152,7 +3152,7 @@ ApolloRTCCMFDButtons::ApolloRTCCMFDButtons()
 
 	RegisterPage(mnu92, sizeof(mnu92) / sizeof(MFDBUTTONMENU));
 
-	RegisterFunction("TGT", OAPI_KEY_T, &ApolloRTCCMFD::set_TargetVessel);
+	RegisterFunction("TGT", OAPI_KEY_T, &ApolloRTCCMFD::set_TargetVesselTable);
 	RegisterFunction("MOD", OAPI_KEY_Q, &ApolloRTCCMFD::menuCycleTPIMode);
 	RegisterFunction("DT", OAPI_KEY_V, &ApolloRTCCMFD::TPIDTDialogue);
 	RegisterFunction("TPI", OAPI_KEY_L, &ApolloRTCCMFD::menuSetTPIguess);


### PR DESCRIPTION
- TPI times page is now compatible with the MPT and uses the input guess time as the vector time
- Vector Panel Summary display properly refreshes even if present GMT is negative
- PDI PAD has better MPT compatibility and uses landing minus 20 minutes as vector time
- Fix SPQ vector time input display overlapping
- VECPOINT angles displayed in all calculation modes
- Show 3 instead of 2 decimal places of REVS1 on TLMCC and LOI inputs